### PR TITLE
Edits in chapter 4

### DIFF
--- a/ran.rst
+++ b/ran.rst
@@ -9,7 +9,7 @@ Chapter 4:  Radio Access Network
    these examples).
 
 The high-level description of the RAN in Chapter 2 was mostly silent
-about the RAN’s internal structure. We now focus on those details, and
+about the RAN's internal structure. We now focus on those details, and
 in doing so, explain how the RAN is being transformed in 5G.
 
 You can think of the RAN as having one main job: to transfer packets
@@ -27,10 +27,9 @@ purview of the 3GPP, but the latter are primarily influenced by a
 second organization: the *Open-RAN Alliance (O-RAN)* introduced in
 Chapter 1. O-RAN is led by network operators with the goal of
 developing a software-based implementation of the RAN that eliminates
-vendor lock-in.  Such business forces are certainly a factor in where
+vendor lock-in. Such business forces are certainly a factor in where
 5G mobile networks are headed, but our goal in this chapter is to
 identify the technical design decisions involved in that evolution.
-
 
 4.1 Packet Processing Pipeline
 ------------------------------
@@ -43,13 +42,13 @@ valid to view it as a protocol stack (as is typically done in official
 3GPP documents). Also note that (for now) we are agnostic as to how
 these stages are implemented. Since we are ultimately heading
 towards a cloud-based implementation, one possible implementation
-strategy would be a microservice per box. 
+strategy would be a microservice per box.
 
 .. _fig-pipeline:
-.. figure:: figures/sdn/Slide1.png 
+.. figure:: figures/sdn/Slide1.png
     :width: 600px
     :align: center
-	    
+
     RAN processing pipeline, including both user and
     control plane components.
 
@@ -57,18 +56,18 @@ The key stages are as follows.
 
 -  RRC (Radio Resource Control) → Responsible for configuring the
    coarse-grained and policy-related aspects of the pipeline. The RRC runs
-   in the RAN’s control plane; it does not process packets in the user
+   in the RAN's control plane; it does not process packets in the user
    plane.
 
 -  PDCP (Packet Data Convergence Protocol) → Responsible for compressing
-   and decompressing IP headers, ciphering and integrity protection, and
-   making an “early” forwarding decision (i.e., whether to send the
-   packet down the pipeline to the UE or forward it to another base
-   station).
+   and decompressing IP headers, ciphering and dechipering, integrity
+   protection and integrity verification, duplication, reordering and
+   in-order delivery, and out-of-order delivery.
 
 -  RLC (Radio Link Control) → Responsible for segmentation and
-   reassembly, including reliably transmitting/receiving segments by
-   implementing a form of ARQ (automatic repeat request).
+   reassembly, including, only for acknowledge mode (AM) data transfer,
+   re-segmentation and reliably transmitting/receiving segments using
+   error correction through ARQ (automatic repeat request).
 
 -  MAC (Media Access Control) → Responsible for buffering, multiplexing
    and demultiplexing segments, including all real-time scheduling
@@ -85,9 +84,9 @@ conversion and the RF front-end) are beyond the scope of this book.
 While it is simplest to view the stages in :numref:`Figure %s
 <fig-pipeline>` as a pure left-to-right pipeline, the Scheduler
 described in Section 3.2 (denoted "S" in the figure) runs in the MAC
-stage, and implements the “main loop” for outbound traffic: It reads
-data from the upstream RLC and schedules transmissions to the
-downstream PHY.  Since the Scheduler determines the number of bytes to
+stage/layer, and implements the “main loop” for outbound traffic:
+It reads data from the upstream RLC and schedules transmissions to the
+downstream PHY. Since the Scheduler determines the number of bytes to
 transmit to a given UE during each time period (based on all the
 factors outlined in Chapter 3), it must request (get) a segment of
 that length from the upstream queue. In practice, the size of the
@@ -100,7 +99,7 @@ the observation made in Section 2.3: that a *"base station can be
 viewed as a specialized forwarder"*. The control plane logic that
 decides whether this base station should continue processing a packet
 or forward it to another base station runs in the RRC, and the
-corresponding data plane mechanism that carries out the forwarding
+corresponding user plane mechanism that carries out the forwarding
 decision is implemented in the PDCP. The interface between these two
 elements is defined by the 3GPP spec, but the decision-making logic is
 an implementation choice (and historically proprietary). This control
@@ -115,7 +114,7 @@ The next step is to understand how the functionality outlined above is
 partitioned between physical elements, and hence, “split” across
 centralized and distributed locations. The dominant option has
 historically been "no split," with the entire pipeline shown in
-:numref:`Figure %s <fig-pipeline>` running in the base station.  Going
+:numref:`Figure %s <fig-pipeline>` running in the base station. Going
 forward, the 3GPP standard has been extended to allow for multiple
 split-points, with the partition shown in :numref:`Figure %s
 <fig-split-ran>` being actively pursued by the operator-led O-RAN
@@ -125,7 +124,7 @@ components mirrors the split made in SDN, with similar motivations. We
 discuss further how SDN techniques are applied to the RAN below.
 
 .. _fig-split-ran:
-.. figure:: figures/sdn/Slide2.png 
+.. figure:: figures/sdn/Slide2.png
     :width: 600px
     :align: center
 
@@ -142,10 +141,10 @@ Scheduler that is part of the MAC stage is responsible for all
 real-time scheduling decisions.
 
 .. _fig-ran-hierarchy:
-.. figure:: figures/sdn/Slide3.png 
+.. figure:: figures/sdn/Slide3.png
     :width: 400px
     :align: center
-	    
+
     Split RAN hierarchy, with one CU serving multiple DUs,
     each of which serves multiple RUs.
 
@@ -161,7 +160,7 @@ to make this latter configuration all the more common.
 
 Also note that the Split RAN changes the nature of the Backhaul
 Network, which originally connected the base stations back to the
-Mobile Core.  With the Split RAN there are multiple connections, which
+Mobile Core. With the Split RAN there are multiple connections, which
 are officially labeled as follows.
 
 -  RU-DU connectivity is called the Fronthaul
@@ -185,7 +184,7 @@ co-locate the CU and Mobile Core in the same cluster, meaning the
 backhaul is implemented in the cluster switching fabric. In such a
 configuration, the midhaul then effectively serves the same purpose as
 the original backhaul, and the fronthaul is constrained by the
-predictable/low-latency requirements of the MAC stage’s real-time
+predictable/low-latency requirements of the MAC stage's real-time
 scheduler. This situation is further complicated by the fact that the
 mobile core itself may be disaggregated, as discussed in Chapter 5.
 
@@ -195,29 +194,29 @@ and the PDCP—which lie on the RAN's control plane and user plane,
 respectively. This separation is consistent with the idea of CUPS
 introduced in Chapter 2, and plays an increasingly important role as
 we dig deeper into how the RAN is implemented. For now, we note that
-the two parts are sometimes referred to as the CU-C and CU-U,
+the two parts are sometimes referred to as the CU-CP and CU-UP,
 respectively.
 
 We conclude our description of the split RAN architecture with the
-alternative depiction in :numref:`Figure %s <fig-split-alt>`. 
-For completeness, this figure identifies the standardized interfaces between the
-components (e.g., N2, N3, F1-U, F1-C, and Open Fronthaul). We're not
-going to talk about these interfaces, except to note that they exist
-and there is a corresponding 3GPP specification that spells out the
-details. Instead, we're going to comment on the availability of open
-source implementations for each component.
+alternative depiction in :numref:`Figure %s <fig-split-alt>`.
+For completeness, this figure identifies the standardized interfaces
+between the components (e.g., N2, N3, F1-U, F1-C, and Open Fronthaul).
+We're not going to talk about these interfaces, except to note that
+they exist and there is a corresponding 3GPP specification that spells
+out the details. Instead, we're going to comment on the availability
+of open source implementations for each component.
 
 .. _fig-split-alt:
-.. figure:: figures/sdn/Slide10.png 
+.. figure:: figures/sdn/Slide10.png
     :width: 150px
     :align: center
-	    
+
     Alternative depiction of the Split RAN components, showing the
     3GPP-specified inter-unit interfaces.
 
 With respect to the Central Unit, most of the complexity is in the
-CU-C, which, as we'll see in the next section, is being re-engineered
-using SDN, with open source solutions available.  With respect to the
+CU-CP, which, as we'll see in the next section, is being re-engineered
+using SDN, with open source solutions available. With respect to the
 Radio Unit, nearly all the complexity is in D/A conversion and how the
 resulting analog signal is amplified. Incumbent vendors have
 significant proprietary know-how in this space, which will almost
@@ -245,7 +244,7 @@ but its usage is restricted to research-only deployments.
 
     `Open Air Interface  <https://openairinterface.org/>`__.
 
-    
+
 4.3 Software-Defined RAN
 ------------------------
 
@@ -254,7 +253,7 @@ principles, resulting in an SD-RAN. The key architectural insight is
 shown in :numref:`Figure %s <fig-rrc-split>`, where the RRC from
 :numref:`Figure %s <fig-pipeline>` is partitioned into two
 sub-components: the one on the left provides a 3GPP-compliant way for
-the RAN to interface to the Mobile Core’s control plane (the figure
+the RAN to interface to the Mobile Core's control plane (the figure
 labels this sub-component as a "Proxy"), while the one on the right
 opens a new programmatic API for exerting software-based control over
 the pipeline that implements the RAN user plane.
@@ -263,28 +262,28 @@ To be more specific, the left sub-component simply forwards control
 packets between the Mobile Core and the PDCP, providing a path over
 which the Mobile Core can communicate with the UE for control
 purposes, whereas the right sub-component implements the core of the
-RRC’s control functionality (which as we explained in Section 4.1 is
+RRC's control functionality (which as we explained in Section 4.1 is
 also known as RRM). This latter component is commonly referred to as
 the *RAN Intelligent Controller (RIC)* in O-RAN architecture
-documents, so we adopt this terminology.  The "Near-Real Time"
+documents, so we adopt this terminology. The "Near-Real Time"
 qualifier indicates the RIC is part of 10-100ms control loop
 implemented in the CU, as opposed to the ~1ms control loop required by
 the MAC scheduler running in the DU.
 
 .. _fig-rrc-split:
-.. figure:: figures/sdn/Slide4.png 
+.. figure:: figures/sdn/Slide4.png
     :width: 600px
     :align: center
-	    
+
     RRC disaggregated into a Mobile Core facing control plane
     component (a proxy) and a Near-Real-Time Controller.
 
 Although not shown in :numref:`Figure %s <fig-rrc-split>`, keep in
 mind (from :numref:`Figure %s <fig-split-ran>`) that the RRC and the
 PDCP form the CU. Reconciling these two figures is a little bit messy, but
-to a first approximation, the PDCP corresponds to the CU-U and
-RRC-Proxy corresponds to the CU-C, with the RIC "lifted out" and
-responsible for overseeing both.  We postpone a diagram depicting this
+to a first approximation, the PDCP corresponds to the CU-UP and
+RRC-Proxy corresponds to the CU-CP, with the RIC "lifted out" and
+responsible for overseeing both. We postpone a diagram depicting this
 relationship until Section 4.5, where we summarize the end-to-end
 result. For now, the important takeaway is that the SDN-inspired
 refactoring of the RAN is free both to move functionality around and to
@@ -292,10 +291,10 @@ introduce new module boundaries, as long as the original 3GPP-defined
 interfaces are preserved.
 
 .. _fig-ran-controller:
-.. figure:: figures/sdn/Slide5.png 
+.. figure:: figures/sdn/Slide5.png
     :width: 400px
     :align: center
-	    
+
     Example set of control applications (xApps) running on top of
     Near-Real-Time RAN Controller (RIC), controlling a distributed set
     of Split RAN elements (CU, DU, RU).
@@ -307,7 +306,7 @@ control apps. The RIC maintains a *RAN Network Information Base
 control apps. The R-NIB includes time-averaged CQI values and other
 per-session state (e.g., GTP tunnel IDs, 5QI values for the type of
 traffic), while the MAC (as part of the DU) maintains the
-instantaneous CQI values required by the real-time scheduler.  More
+instantaneous CQI values required by the real-time scheduler. More
 generally, the R-NIB includes the following state:
 
 * Fixed Nodes (RU/DU/CU Attributes)
@@ -327,7 +326,7 @@ generally, the R-NIB includes the following state:
     -  Measurement Config
     -  State (Active/Idle)
 
-  - Links (*Actual*  and *Potential*)
+  - Links (*Actual* and *Potential*)
 
     -  Identifiers
     -  Link Type
@@ -370,7 +369,7 @@ controlling the mobile link at two different levels. At a fine-grained
 level, per-node and per-link control are conducted using the RRM
 functions that are distributed across the individual base stations.\
 [#]_ RRM functions include scheduling, handover control, link and
-carrier aggregation control, bearer control, and access control.  At a
+carrier aggregation control, bearer control, and access control. At a
 coarse-grained level, regional mobile network optimization and
 configuration is conducted using *Self-Organizing Network (SON)*
 functions. These functions oversee neighbor lists, manage load
@@ -394,12 +393,11 @@ SDN is transforming the RAN, so new ways of controlling the
 RAN—resulting in applications that do not fit neatly into the RRM vs SON
 dichotomy—can be expected to emerge over time.
 
-
 4.4 Near Real-Time RIC
 ----------------------
 
-.. This is where we talk about some implementation details for the  
-   ONOS RIC. Currently cut-and-pasted from SDN book, where there  
+.. This is where we talk about some implementation details for the
+   ONOS RIC. Currently cut-and-pasted from SDN book, where there
    was significant assumed knowledge of ONOS.
 
 Drilling down to the next level of detail, :numref:`Figure %s
@@ -441,7 +439,7 @@ unified API (and corresponding SDK) for building RIC-agnostic xApps.
 
 The A1 interface provides a means for the mobile operator's management
 plane—typically called the *OSS/BSS (Operations Support System /
-Business Support System)* in the Telco world—to configure the RAN.  We
+Business Support System)* in the Telco world—to configure the RAN. We
 briefly introduced the OSS/BSS in Section 2.5, but all you need to
 know about it for our purposes is that such a component sits at the
 top of all Telco software stacks. It is the source of all
@@ -468,22 +466,25 @@ operations against this Service Model.
 
 Of course, it is the RAN element, through its published Service Model,
 that defines the relevant set of functions that can be activated, the
-variables that can be reported, and policies that can be set.  The
-O-RAN community is working on two vendor-agnostic Service Models. The
+variables that can be reported, and policies that can be set. The
+O-RAN community is working on a few vendor-agnostic Service Models. The
 first, called *Key Performance Measurement* (abbreviated *E2SM-KPM*),
 specifies the metrics that can be retrieved from RAN elements. The
 second, called *RAN Control* (abbreviated *E2SM-RC*), specifies
-parameters that can be set to control RAN elements.
+parameters that can be set to control RAN elements. And the third,
+called *Cell Configuration and Control* (abbreviated *E2SM-CCC*),
+used to expose and initiate control and/or configuration of node
+level and cell level configuration and/or parameters.
 
 In simple terms, E2SM-KPM defines what values can be *read* and
-E2SM-RC defines what values can be *written*. Because the available
-values can be highly variable across all possible devices, we can
-expect different vendors will support only a subset of the entire
-collection. This will limit the "universality" the O-RAN was hoping to
-achieve in an effort to break vendor lock-in, but that outcome is
-familiar to network operators who have been dealing with divergent
-*Management Information Bases (MIBs)* since the earliest days of the
-Internet.
+E2SM-RC and E2SM-CCC defines what values can be *written*. Because
+the available values can be highly variable across all possible
+devices, we can expect different vendors will support only a subset
+of the entire collection. This will limit the "universality" the
+O-RAN was hoping to achieve in an effort to break vendor lock-in,
+but that outcome is familiar to network operators who have been
+dealing with divergent *Management Information Bases (MIBs)* since
+the earliest days of the Internet.
 
 Finally, the xApp SDK, which is specific to the ONOS-based
 implementation, is currently little more than a "pass through" of the
@@ -500,11 +501,11 @@ SDK currently makes the gRPC-based API available to xApps.
 .. _reading_onos:
 .. admonition:: Further Reading
 
-   
+
    To learn more about the details of ONOS and its interfaces, we
    recommend the chapter in our SDN book that covers it in
    depth. `Software-Defined Networks: A Systems Approach. Chapter 6:
-   Network OS <https://sdn.systemsapproach.org/onos.html>`__.  
+   Network OS <https://sdn.systemsapproach.org/onos.html>`__.
 
 
 
@@ -526,26 +527,26 @@ specific disaggregation options from 3GPP and is developing open
 interfaces between these components.
 
 .. _fig-disagg1:
-.. figure:: figures/sdn/Slide7.png 
-    :width: 450px 
-    :align: center 
-       
+.. figure:: figures/sdn/Slide7.png
+    :width: 450px
+    :align: center
+
     First tier of RAN disaggregation: Split RAN.
 
 The second tier of disaggregation focuses on the control/user plane
-separation (CUPS) of the CU, resulting in the CU-U and CU-C shown in
+separation (CUPS) of the CU, resulting in the CU-UP and CU-CP shown in
 :numref:`Figure %s <fig-disagg2>`. The control plane in question is
-the 3GPP control plane, where the CU-U realizes a pipeline for user
-traffic and the CU-C focuses on control message signaling between
+the 3GPP control plane, where the CU-UP realizes a pipeline for user
+traffic and the CU-CP focuses on control message signaling between
 Mobile Core and the disaggregated RAN components (as well as to the
 UE).
 
 .. _fig-disagg2:
-.. figure:: figures/sdn/Slide8.png 
-    :width: 450px 
-    :align: center 
-       
-    Second tier of RAN disaggregation: CUPS. 
+.. figure:: figures/sdn/Slide8.png
+    :width: 450px
+    :align: center
+
+    Second tier of RAN disaggregation: CUPS.
 
 The third tier follows the SDN paradigm by separating most of RAN
 control (RRC functions) from the disaggregated RAN components, and
@@ -555,16 +556,16 @@ Controller, which corresponds to the Near-RT RIC shown previously in
 <fig-ran-controller>`. This SDN-based disaggregation is repeated in
 :numref:`Figure %s <fig-ctl_loops>`, which also shows the
 O-RAN-prescribed interfaces A1 and E2 introduced in the previous
-section.  (Note that all the edges in :numref:`Figures %s
+section. (Note that all the edges in :numref:`Figures %s
 <fig-disagg1>` and :numref:`%s <fig-disagg2>` correspond to
 3GPP-defined interfaces, as identified in Section 4.2, but their
 details are outside the scope of this discussion.)
-    
+
 .. _fig-ctl_loops:
-.. figure:: figures/sdn/Slide9.png 
-    :width: 800px 
+.. figure:: figures/sdn/Slide9.png
+    :width: 800px
     :align: center
-       
+
     Third tier of RAN disaggregation: SDN.
 
 Taken together, the A1 and E2 interfaces complete two of the three
@@ -576,7 +577,7 @@ inside the DU—includes the real-time Scheduler embedded in the MAC
 stage of the RAN pipeline. The two outer control loops have rough time
 bounds of >>1sec and >10ms, respectively. As we saw in Chapter 2,
 the real-time control loop is assumed to be <1ms.
- 
+
 This raises the question of how specific functionality is distributed
 between the Non-RT RIC, Near-RT RIC, and DU. Starting with the second
 pair (i.e., the two inner loops), it is the case that not all RRC
@@ -598,5 +599,3 @@ RT-RIC, and their non-real-time learning counterparts would run
 elsewhere. The Non-RT RIC would then interact with the Near-RT RIC to
 deliver relevant operator policies from the Management Plane to the
 Near RT-RIC over the A1 interface.
-
-


### PR DESCRIPTION
This PR includes:

- Update text about PDCP aligned to TS 38.323
- Update text about RLC aligned to TS 38.322
- Changed CU-C and CU-U to CU-CP and CU-UP, respectively, to be aligned to TS 38.401and O-RAN terminology
  - **Note:** Figures need to be properly updated
- Modified text and added description about E2SM-CCC service model
- Other minor edits

**Suggestion:**
From figure 30, remove "Python" from the `xApp SDK` component because it is no longer supported/maintained